### PR TITLE
Mask protected fields by default and add --print-protected-fields flag

### DIFF
--- a/src/main/java/com/github/ai/kpdiff/domain/MainInteractor.kt
+++ b/src/main/java/com/github/ai/kpdiff/domain/MainInteractor.kt
@@ -76,7 +76,7 @@ class MainInteractor(
             val options = DiffFormatterOptions(
                 isColorEnabled = !parsedArgs.isNoColoredOutput,
                 isVerboseOutput = parsedArgs.isVerboseOutput,
-                isPrintProtectedFields = parsedArgs.isPrintProtectedFields
+                isReveal = parsedArgs.isReveal
             )
 
             printDiffUseCase.printDiff(

--- a/src/main/java/com/github/ai/kpdiff/domain/MainInteractor.kt
+++ b/src/main/java/com/github/ai/kpdiff/domain/MainInteractor.kt
@@ -75,7 +75,8 @@ class MainInteractor(
         } else {
             val options = DiffFormatterOptions(
                 isColorEnabled = !parsedArgs.isNoColoredOutput,
-                isVerboseOutput = parsedArgs.isVerboseOutput
+                isVerboseOutput = parsedArgs.isVerboseOutput,
+                isPrintProtectedFields = parsedArgs.isPrintProtectedFields
             )
 
             printDiffUseCase.printDiff(

--- a/src/main/java/com/github/ai/kpdiff/domain/argument/ArgumentParser.kt
+++ b/src/main/java/com/github/ai/kpdiff/domain/argument/ArgumentParser.kt
@@ -96,6 +96,8 @@ class ArgumentParser(
             OptionalArgument.HELP -> parseHelp(values)
             OptionalArgument.VERSION -> parseVersion(values)
             OptionalArgument.VERBOSE -> parseVerbose(values)
+            OptionalArgument.PRINT_PROTECTED_FIELDS -> parsePrintProtectedFields(values)
+            OptionalArgument.PRINT_PASSWORDS -> parsePrintProtectedFields(values)
             OptionalArgument.KEY_FILE_A -> parseLeftKeyPath(queue.poll(), values)
             OptionalArgument.KEY_FILE_B -> parseRightKeyPath(queue.poll(), values)
             OptionalArgument.PASSWORD -> parsePassword(queue.poll(), values)
@@ -149,6 +151,11 @@ class ArgumentParser(
 
     private fun parseVerbose(arguments: MutableArguments): Either<Unit> {
         arguments.isVerboseOutput = true
+        return Either.Right(Unit)
+    }
+
+    private fun parsePrintProtectedFields(arguments: MutableArguments): Either<Unit> {
+        arguments.isPrintProtectedFields = true
         return Either.Right(Unit)
     }
 

--- a/src/main/java/com/github/ai/kpdiff/domain/argument/ArgumentParser.kt
+++ b/src/main/java/com/github/ai/kpdiff/domain/argument/ArgumentParser.kt
@@ -96,8 +96,7 @@ class ArgumentParser(
             OptionalArgument.HELP -> parseHelp(values)
             OptionalArgument.VERSION -> parseVersion(values)
             OptionalArgument.VERBOSE -> parseVerbose(values)
-            OptionalArgument.PRINT_PROTECTED_FIELDS -> parsePrintProtectedFields(values)
-            OptionalArgument.PRINT_PASSWORDS -> parsePrintProtectedFields(values)
+            OptionalArgument.REVEAL -> parseReveal(values)
             OptionalArgument.KEY_FILE_A -> parseLeftKeyPath(queue.poll(), values)
             OptionalArgument.KEY_FILE_B -> parseRightKeyPath(queue.poll(), values)
             OptionalArgument.PASSWORD -> parsePassword(queue.poll(), values)
@@ -154,8 +153,8 @@ class ArgumentParser(
         return Either.Right(Unit)
     }
 
-    private fun parsePrintProtectedFields(arguments: MutableArguments): Either<Unit> {
-        arguments.isPrintProtectedFields = true
+    private fun parseReveal(arguments: MutableArguments): Either<Unit> {
+        arguments.isReveal = true
         return Either.Right(Unit)
     }
 

--- a/src/main/java/com/github/ai/kpdiff/domain/argument/ArgumentsExtensions.kt
+++ b/src/main/java/com/github/ai/kpdiff/domain/argument/ArgumentsExtensions.kt
@@ -24,6 +24,6 @@ fun MutableArguments.toArguments(): Arguments {
         isPrintHelp = isPrintHelp,
         isPrintVersion = isPrintVersion,
         isVerboseOutput = isVerboseOutput,
-        isPrintProtectedFields = isPrintProtectedFields
+        isReveal = isReveal
     )
 }

--- a/src/main/java/com/github/ai/kpdiff/domain/argument/ArgumentsExtensions.kt
+++ b/src/main/java/com/github/ai/kpdiff/domain/argument/ArgumentsExtensions.kt
@@ -23,6 +23,7 @@ fun MutableArguments.toArguments(): Arguments {
         isNoColoredOutput = isNoColoredOutput,
         isPrintHelp = isPrintHelp,
         isPrintVersion = isPrintVersion,
-        isVerboseOutput = isVerboseOutput
+        isVerboseOutput = isVerboseOutput,
+        isPrintProtectedFields = isPrintProtectedFields
     )
 }

--- a/src/main/java/com/github/ai/kpdiff/domain/argument/OptionalArgument.kt
+++ b/src/main/java/com/github/ai/kpdiff/domain/argument/OptionalArgument.kt
@@ -22,7 +22,9 @@ enum class OptionalArgument(
     PASSWORD_B(shortName = null, fullName = "password-b"),
     VERBOSE(shortName = "v", fullName = "verbose"),
     DIFF_BY(shortName = "d", fullName = "diff-by"),
-    OUTPUT_FILE(shortName = "f", fullName = "output-file");
+    OUTPUT_FILE(shortName = "f", fullName = "output-file"),
+    PRINT_PROTECTED_FIELDS(shortName = null, fullName = "print-protected-fields"),
+    PRINT_PASSWORDS(shortName = null, fullName = "print-passwords");
 
     val cliShortName: String? = if (shortName != null) {
         "-$shortName"

--- a/src/main/java/com/github/ai/kpdiff/domain/argument/OptionalArgument.kt
+++ b/src/main/java/com/github/ai/kpdiff/domain/argument/OptionalArgument.kt
@@ -23,8 +23,7 @@ enum class OptionalArgument(
     VERBOSE(shortName = "v", fullName = "verbose"),
     DIFF_BY(shortName = "d", fullName = "diff-by"),
     OUTPUT_FILE(shortName = "f", fullName = "output-file"),
-    PRINT_PROTECTED_FIELDS(shortName = null, fullName = "print-protected-fields"),
-    PRINT_PASSWORDS(shortName = null, fullName = "print-passwords");
+    REVEAL(shortName = null, fullName = "reveal");
 
     val cliShortName: String? = if (shortName != null) {
         "-$shortName"

--- a/src/main/java/com/github/ai/kpdiff/domain/diff/formatter/DiffFormatterImpl.kt
+++ b/src/main/java/com/github/ai/kpdiff/domain/diff/formatter/DiffFormatterImpl.kt
@@ -194,14 +194,56 @@ class DiffFormatterImpl(
         val formatter = formatterProvider.getFormatter(entity::class)
             as EntityFormatter<DatabaseEntity>
 
+        val formattedEvent = event.maskProtectedFields(options)
+
         return terminalOutputFormatter.format(
-            line = formatter.format(event as DiffEvent<DatabaseEntity>, indent),
+            line = formatter.format(formattedEvent as DiffEvent<DatabaseEntity>, indent),
             color = if (options.isColorEnabled) {
                 event.getColor()
             } else {
                 Color.NONE
             }
         )
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T : DatabaseEntity> DiffEvent<T>.maskProtectedFields(
+        options: DiffFormatterOptions
+    ): DiffEvent<T> {
+        if (options.isPrintProtectedFields) {
+            return this
+        }
+
+        return when (this) {
+            is DiffEvent.Insert -> DiffEvent.Insert(
+                parentUuid = parentUuid,
+                entity = entity.maskProtectedField()
+            ) as DiffEvent<T>
+
+            is DiffEvent.Delete -> DiffEvent.Delete(
+                parentUuid = parentUuid,
+                entity = entity.maskProtectedField()
+            ) as DiffEvent<T>
+
+            is DiffEvent.Update -> DiffEvent.Update(
+                oldParentUuid = oldParentUuid,
+                newParentUuid = newParentUuid,
+                oldEntity = oldEntity.maskProtectedField(),
+                newEntity = newEntity.maskProtectedField()
+            ) as DiffEvent<T>
+        }
+    }
+
+    private fun <T : DatabaseEntity> T.maskProtectedField(): T {
+        if (this !is Field<*> || name != Fields.FIELD_PASSWORD) {
+            return this
+        }
+
+        return Field(
+            uuid = uuid,
+            name = name,
+            value = PROTECTED_FIELD_PLACEHOLDER
+        ) as T
     }
 
     private fun shouldPrintAdditionalInformation(
@@ -275,6 +317,8 @@ class DiffFormatterImpl(
 
     companion object {
         private const val INDENT = "    "
+
+        private const val PROTECTED_FIELD_PLACEHOLDER = "***"
 
         private val DEFAULT_PROPERTIES = setOf(
             Fields.FIELD_TITLE,

--- a/src/main/java/com/github/ai/kpdiff/domain/diff/formatter/DiffFormatterImpl.kt
+++ b/src/main/java/com/github/ai/kpdiff/domain/diff/formatter/DiffFormatterImpl.kt
@@ -194,7 +194,7 @@ class DiffFormatterImpl(
         val formatter = formatterProvider.getFormatter(entity::class)
             as EntityFormatter<DatabaseEntity>
 
-        val formattedEvent = event.maskProtectedFields(options)
+        val formattedEvent = event.maskProtectedFieldsUnlessRevealed(options)
 
         return terminalOutputFormatter.format(
             line = formatter.format(formattedEvent as DiffEvent<DatabaseEntity>, indent),
@@ -207,10 +207,10 @@ class DiffFormatterImpl(
     }
 
     @Suppress("UNCHECKED_CAST")
-    private fun <T : DatabaseEntity> DiffEvent<T>.maskProtectedFields(
+    private fun <T : DatabaseEntity> DiffEvent<T>.maskProtectedFieldsUnlessRevealed(
         options: DiffFormatterOptions
     ): DiffEvent<T> {
-        if (options.isPrintProtectedFields) {
+        if (options.isReveal) {
             return this
         }
 

--- a/src/main/java/com/github/ai/kpdiff/domain/usecases/PrintHelpUseCase.kt
+++ b/src/main/java/com/github/ai/kpdiff/domain/usecases/PrintHelpUseCase.kt
@@ -43,8 +43,7 @@ class PrintHelpUseCase(
                 -d, --diff-by                    Type of differ, default is 'path'. Possible values:
                                                       path - produces more accurate diff, considers entries identical if they have identical content but UUID differs
                                                       uuid - considers entries identical if they have identical content and UUID
-                    --print-protected-fields    Print values of protected fields such as passwords
-                    --print-passwords            Alias for --print-protected-fields
+                    --reveal                     Reveal protected field values such as passwords
                 -v, --verbose                    Print verbose output (entry fields will be printed)
                 -V, --version                    Print version
                 -h, --help                       Print help information

--- a/src/main/java/com/github/ai/kpdiff/domain/usecases/PrintHelpUseCase.kt
+++ b/src/main/java/com/github/ai/kpdiff/domain/usecases/PrintHelpUseCase.kt
@@ -43,6 +43,8 @@ class PrintHelpUseCase(
                 -d, --diff-by                    Type of differ, default is 'path'. Possible values:
                                                       path - produces more accurate diff, considers entries identical if they have identical content but UUID differs
                                                       uuid - considers entries identical if they have identical content and UUID
+                    --print-protected-fields    Print values of protected fields such as passwords
+                    --print-passwords            Alias for --print-protected-fields
                 -v, --verbose                    Print verbose output (entry fields will be printed)
                 -V, --version                    Print version
                 -h, --help                       Print help information

--- a/src/main/java/com/github/ai/kpdiff/entity/Arguments.kt
+++ b/src/main/java/com/github/ai/kpdiff/entity/Arguments.kt
@@ -21,7 +21,7 @@ data class Arguments(
     val isPrintHelp: Boolean,
     val isPrintVersion: Boolean,
     val isVerboseOutput: Boolean,
-    val isPrintProtectedFields: Boolean
+    val isReveal: Boolean
 ) {
 
     companion object {
@@ -44,7 +44,7 @@ data class Arguments(
             isPrintHelp = false,
             isPrintVersion = false,
             isVerboseOutput = false,
-            isPrintProtectedFields = false
+            isReveal = false
         )
     }
 }

--- a/src/main/java/com/github/ai/kpdiff/entity/Arguments.kt
+++ b/src/main/java/com/github/ai/kpdiff/entity/Arguments.kt
@@ -20,7 +20,8 @@ data class Arguments(
     val isNoColoredOutput: Boolean,
     val isPrintHelp: Boolean,
     val isPrintVersion: Boolean,
-    val isVerboseOutput: Boolean
+    val isVerboseOutput: Boolean,
+    val isPrintProtectedFields: Boolean
 ) {
 
     companion object {
@@ -42,7 +43,8 @@ data class Arguments(
             isNoColoredOutput = false,
             isPrintHelp = false,
             isPrintVersion = false,
-            isVerboseOutput = false
+            isVerboseOutput = false,
+            isPrintProtectedFields = false
         )
     }
 }

--- a/src/main/java/com/github/ai/kpdiff/entity/DiffFormatterOptions.kt
+++ b/src/main/java/com/github/ai/kpdiff/entity/DiffFormatterOptions.kt
@@ -3,5 +3,5 @@ package com.github.ai.kpdiff.entity
 data class DiffFormatterOptions(
     val isColorEnabled: Boolean = true,
     val isVerboseOutput: Boolean = false,
-    val isPrintProtectedFields: Boolean = false
+    val isReveal: Boolean = false
 )

--- a/src/main/java/com/github/ai/kpdiff/entity/DiffFormatterOptions.kt
+++ b/src/main/java/com/github/ai/kpdiff/entity/DiffFormatterOptions.kt
@@ -2,5 +2,6 @@ package com.github.ai.kpdiff.entity
 
 data class DiffFormatterOptions(
     val isColorEnabled: Boolean = true,
-    val isVerboseOutput: Boolean = false
+    val isVerboseOutput: Boolean = false,
+    val isPrintProtectedFields: Boolean = false
 )

--- a/src/main/java/com/github/ai/kpdiff/entity/MutableArguments.kt
+++ b/src/main/java/com/github/ai/kpdiff/entity/MutableArguments.kt
@@ -19,5 +19,5 @@ data class MutableArguments(
     var isPrintHelp: Boolean = false,
     var isPrintVersion: Boolean = false,
     var isVerboseOutput: Boolean = false,
-    var isPrintProtectedFields: Boolean = false
+    var isReveal: Boolean = false
 )

--- a/src/main/java/com/github/ai/kpdiff/entity/MutableArguments.kt
+++ b/src/main/java/com/github/ai/kpdiff/entity/MutableArguments.kt
@@ -18,5 +18,6 @@ data class MutableArguments(
     var isNoColoredOutput: Boolean = false,
     var isPrintHelp: Boolean = false,
     var isPrintVersion: Boolean = false,
-    var isVerboseOutput: Boolean = false
+    var isVerboseOutput: Boolean = false,
+    var isPrintProtectedFields: Boolean = false
 )

--- a/src/test/java/com/github/ai/kpdiff/domain/MainInteractorTest.kt
+++ b/src/test/java/com/github/ai/kpdiff/domain/MainInteractorTest.kt
@@ -269,7 +269,8 @@ class MainInteractorTest {
             isNoColoredOutput = isNoColoredOutput,
             isPrintHelp = isPrintHelp,
             isPrintVersion = isPrintVersion,
-            isVerboseOutput = false
+            isVerboseOutput = false,
+            isPrintProtectedFields = false
         )
 
     private fun newInteractor(): MainInteractor =

--- a/src/test/java/com/github/ai/kpdiff/domain/MainInteractorTest.kt
+++ b/src/test/java/com/github/ai/kpdiff/domain/MainInteractorTest.kt
@@ -270,7 +270,7 @@ class MainInteractorTest {
             isPrintHelp = isPrintHelp,
             isPrintVersion = isPrintVersion,
             isVerboseOutput = false,
-            isPrintProtectedFields = false
+            isReveal = false
         )
 
     private fun newInteractor(): MainInteractor =

--- a/src/test/java/com/github/ai/kpdiff/domain/argument/ArgumentParserTest.kt
+++ b/src/test/java/com/github/ai/kpdiff/domain/argument/ArgumentParserTest.kt
@@ -206,24 +206,19 @@ internal class ArgumentParserTest {
 
 
     @Test
-    fun `parse should return arguments if protected-field printing is specified`() {
-        listOf(
-            OptionalArgument.PRINT_PROTECTED_FIELDS.cliFullName,
-            OptionalArgument.PRINT_PASSWORDS.cliFullName
-        ).forEach { argumentName ->
-            assertParsedSuccessfully(
-                arguments = arrayOf(
-                    LEFT_FILE_PATH,
-                    RIGHT_FILE_PATH,
-                    argumentName
-                ),
-                expectedArguments = newArguments(
-                    LEFT_FILE_PATH,
-                    RIGHT_FILE_PATH,
-                    isPrintProtectedFields = true
-                )
+    fun `parse should return arguments if --reveal is specified`() {
+        assertParsedSuccessfully(
+            arguments = arrayOf(
+                LEFT_FILE_PATH,
+                RIGHT_FILE_PATH,
+                OptionalArgument.REVEAL.cliFullName
+            ),
+            expectedArguments = newArguments(
+                LEFT_FILE_PATH,
+                RIGHT_FILE_PATH,
+                isReveal = true
             )
-        }
+        )
     }
 
     @Test
@@ -697,7 +692,7 @@ internal class ArgumentParserTest {
         isPrintHelp: Boolean = false,
         isPrintVersion: Boolean = false,
         isVerboseOutput: Boolean = false,
-        isPrintProtectedFields: Boolean = false
+        isReveal: Boolean = false
     ): Arguments {
         return Arguments(
             leftPath = leftPath,
@@ -718,7 +713,7 @@ internal class ArgumentParserTest {
             isPrintHelp = isPrintHelp,
             isPrintVersion = isPrintVersion,
             isVerboseOutput = isVerboseOutput,
-            isPrintProtectedFields = isPrintProtectedFields
+            isReveal = isReveal
         )
     }
 

--- a/src/test/java/com/github/ai/kpdiff/domain/argument/ArgumentParserTest.kt
+++ b/src/test/java/com/github/ai/kpdiff/domain/argument/ArgumentParserTest.kt
@@ -204,6 +204,28 @@ internal class ArgumentParserTest {
         }
     }
 
+
+    @Test
+    fun `parse should return arguments if protected-field printing is specified`() {
+        listOf(
+            OptionalArgument.PRINT_PROTECTED_FIELDS.cliFullName,
+            OptionalArgument.PRINT_PASSWORDS.cliFullName
+        ).forEach { argumentName ->
+            assertParsedSuccessfully(
+                arguments = arrayOf(
+                    LEFT_FILE_PATH,
+                    RIGHT_FILE_PATH,
+                    argumentName
+                ),
+                expectedArguments = newArguments(
+                    LEFT_FILE_PATH,
+                    RIGHT_FILE_PATH,
+                    isPrintProtectedFields = true
+                )
+            )
+        }
+    }
+
     @Test
     fun `parse should return arguments if --one-password is specified`() {
         listOf(
@@ -674,7 +696,8 @@ internal class ArgumentParserTest {
         isNoColoredOutput: Boolean = false,
         isPrintHelp: Boolean = false,
         isPrintVersion: Boolean = false,
-        isVerboseOutput: Boolean = false
+        isVerboseOutput: Boolean = false,
+        isPrintProtectedFields: Boolean = false
     ): Arguments {
         return Arguments(
             leftPath = leftPath,
@@ -694,7 +717,8 @@ internal class ArgumentParserTest {
             isNoColoredOutput = isNoColoredOutput,
             isPrintHelp = isPrintHelp,
             isPrintVersion = isPrintVersion,
-            isVerboseOutput = isVerboseOutput
+            isVerboseOutput = isVerboseOutput,
+            isPrintProtectedFields = isPrintProtectedFields
         )
     }
 

--- a/src/test/java/com/github/ai/kpdiff/domain/diff/formatter/DiffFormatterImplTest.kt
+++ b/src/test/java/com/github/ai/kpdiff/domain/diff/formatter/DiffFormatterImplTest.kt
@@ -19,7 +19,7 @@ class DiffFormatterImplTest {
         listOf(
             Pair(defaultOptions(), newPathDiffer()) to OUTPUT,
             Pair(verboseOptions(), newPathDiffer()) to VERBOSE_OUTPUT,
-            Pair(printProtectedOptions(), newPathDiffer()) to VERBOSE_OUTPUT_WITH_PROTECTED_FIELDS
+            Pair(revealOptions(), newPathDiffer()) to REVEALED_VERBOSE_OUTPUT
         ).forEach { (data, expected) ->
             // arrange
             val (options, differ) = data
@@ -54,11 +54,11 @@ class DiffFormatterImplTest {
     private fun verboseOptions(): DiffFormatterOptions =
         DiffFormatterOptions(isColorEnabled = false, isVerboseOutput = true)
 
-    private fun printProtectedOptions(): DiffFormatterOptions =
+    private fun revealOptions(): DiffFormatterOptions =
         DiffFormatterOptions(
             isColorEnabled = false,
             isVerboseOutput = true,
-            isPrintProtectedFields = true
+            isReveal = true
         )
 
     companion object {
@@ -129,7 +129,7 @@ class DiffFormatterImplTest {
             +                 Field 'Notes': ''
         """.transformOutput()
 
-        private val VERBOSE_OUTPUT_WITH_PROTECTED_FIELDS = VERBOSE_OUTPUT.map { line ->
+        private val REVEALED_VERBOSE_OUTPUT = VERBOSE_OUTPUT.map { line ->
             line.replace("Field 'Password': '***'", "Field 'Password': 'abc123'")
         }
 

--- a/src/test/java/com/github/ai/kpdiff/domain/diff/formatter/DiffFormatterImplTest.kt
+++ b/src/test/java/com/github/ai/kpdiff/domain/diff/formatter/DiffFormatterImplTest.kt
@@ -18,7 +18,8 @@ class DiffFormatterImplTest {
     fun `format should return diff between databases`() {
         listOf(
             Pair(defaultOptions(), newPathDiffer()) to OUTPUT,
-            Pair(verboseOptions(), newPathDiffer()) to VERBOSE_OUTPUT
+            Pair(verboseOptions(), newPathDiffer()) to VERBOSE_OUTPUT,
+            Pair(printProtectedOptions(), newPathDiffer()) to VERBOSE_OUTPUT_WITH_PROTECTED_FIELDS
         ).forEach { (data, expected) ->
             // arrange
             val (options, differ) = data
@@ -52,6 +53,13 @@ class DiffFormatterImplTest {
 
     private fun verboseOptions(): DiffFormatterOptions =
         DiffFormatterOptions(isColorEnabled = false, isVerboseOutput = true)
+
+    private fun printProtectedOptions(): DiffFormatterOptions =
+        DiffFormatterOptions(
+            isColorEnabled = false,
+            isVerboseOutput = true,
+            isPrintProtectedFields = true
+        )
 
     companion object {
         private val OUTPUT = """
@@ -97,13 +105,13 @@ class DiffFormatterImplTest {
             -             Entry 'Github.com'
             -                 Field 'Title': 'Github.com'
             -                 Field 'UserName': 'john.doe@example.com'
-            -                 Field 'Password': 'abc123'
+            -                 Field 'Password': '***'
             -                 Field 'URL': 'https://github.com'
             -                 Field 'Notes': ''
             +             Entry 'Gitlab'
             +                 Field 'Title': 'Gitlab'
             +                 Field 'UserName': 'john.doe@example.com'
-            +                 Field 'Password': 'abc123'
+            +                 Field 'Password': '***'
             +                 Field 'URL': 'https://gitlab.com'
             +                 Field 'Notes': ''
             ~ Group 'Database'
@@ -116,10 +124,14 @@ class DiffFormatterImplTest {
             +             Entry 'Facebook'
             +                 Field 'Title': 'Facebook'
             +                 Field 'UserName': 'john.doe@example.com'
-            +                 Field 'Password': 'abc123'
+            +                 Field 'Password': '***'
             +                 Field 'URL': 'https://facebook.com'
             +                 Field 'Notes': ''
         """.transformOutput()
+
+        private val VERBOSE_OUTPUT_WITH_PROTECTED_FIELDS = VERBOSE_OUTPUT.map { line ->
+            line.replace("Field 'Password': '***'", "Field 'Password': 'abc123'")
+        }
 
         private fun String.transformOutput(): List<String> {
             return this

--- a/src/test/java/com/github/ai/kpdiff/domain/usecases/GetKeysUseCaseTest.kt
+++ b/src/test/java/com/github/ai/kpdiff/domain/usecases/GetKeysUseCaseTest.kt
@@ -344,7 +344,8 @@ class GetKeysUseCaseTest {
             isAskRightPassword = isAskRightPassword,
             isPrintHelp = false,
             isPrintVersion = false,
-            isVerboseOutput = false
+            isVerboseOutput = false,
+            isPrintProtectedFields = false
         )
     }
 }

--- a/src/test/java/com/github/ai/kpdiff/domain/usecases/GetKeysUseCaseTest.kt
+++ b/src/test/java/com/github/ai/kpdiff/domain/usecases/GetKeysUseCaseTest.kt
@@ -345,7 +345,7 @@ class GetKeysUseCaseTest {
             isPrintHelp = false,
             isPrintVersion = false,
             isVerboseOutput = false,
-            isPrintProtectedFields = false
+            isReveal = false
         )
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent leaking sensitive/protected values (passwords) in diff output by default. 
- Provide an explicit opt-in flag so users can request printing protected values when required.

### Description
- Mask protected field values by default in formatter output by replacing password values with the placeholder `"***"` in `DiffFormatterImpl` via a new `maskProtectedFields` helper.  
- Add CLI options `--print-protected-fields` and `--print-passwords` in `OptionalArgument` and wire them through `ArgumentParser` into the parsed `Arguments` and `MutableArguments`.  
- Propagate the new option into runtime formatting via `DiffFormatterOptions` and `MainInteractor` so stdout formatting respects the opt-in.  
- Update help text in `PrintHelpUseCase` and adjust unit tests (`DiffFormatterImplTest`, `ArgumentParserTest`, `MainInteractorTest`, `GetKeysUseCaseTest`, and related helpers) to cover default masking and explicit opt-in behavior.

### Testing
- Ran `git diff --check` which produced no warnings.  
- Attempted to run the full test suite with Gradle: `./gradlew test --stacktrace` failed under the environment default Java (`25.0.2`) due to Kotlin Gradle tooling incompatibility, and `JAVA_HOME=/root/.local/share/mise/installs/java/17.0.2 ./gradlew test --offline` failed due to plugin resolution not available in the offline/local cache; no project unit tests were able to complete in this environment.  
- Updated unit test expectations to assert masked output by default and restored values when `isPrintProtectedFields` is enabled; these tests were modified but could not be executed fully here due to the Gradle/tooling issues described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fd0ddca0c8322b3c0128adb8fe837)